### PR TITLE
Avoid claims of open source

### DIFF
--- a/docs/factory-deployer.rst
+++ b/docs/factory-deployer.rst
@@ -8,7 +8,7 @@ The ``Factory`` contract is used to deploy new Curve pools and to find existing 
 
     `0xfD6f33A0509ec67dEFc500755322aBd9Df1bD5B8 <https://etherscan.io/address/0xfD6f33A0509ec67dEFc500755322aBd9Df1bD5B8>`_
 
-Source code for this contract is available on `Github <https://github.com/curvefi/curve-factory/blob/master/contracts/Factory.vy>`_.
+Source code for this contract is may be viewed on `Github <https://github.com/curvefi/curve-factory/blob/master/contracts/Factory.vy>`_.
 
 .. _factory-deployer-deployment:
 

--- a/docs/factory-overview.rst
+++ b/docs/factory-overview.rst
@@ -6,7 +6,7 @@ MetaPool Factory
 
 The metapool factory allows for permissionless deployment of Curve metapools.
 
-Factory contracts are open source and may be `found on Github <https://github.com/curvefi/curve-factory>`_.
+Source code for factory contracts may be viewed on `Github <https://github.com/curvefi/curve-factory>`_.
 
 Organization
 ============

--- a/docs/factory-pools.rst
+++ b/docs/factory-pools.rst
@@ -6,7 +6,7 @@ Metapool Factory: Pools
 
 Factory pools are permissionless metapools that can be deployed by anyone. New pools are deployed using :func:`Factory.deploy_metapool<Factory.deploy_metapool>`.
 
-Source code for the implementation contracts is available on `Github <https://github.com/iamdefinitelyahuman/curve-factory/blob/master/contracts>`_.
+Source code for the implementation contracts may be viewed on `Github <https://github.com/iamdefinitelyahuman/curve-factory/blob/master/contracts>`_.
 
 Implementation Contracts
 ========================


### PR DESCRIPTION
Open source sometimes has a connotation of free for use or modification. Because some of our code is proprietary, a more accurate description is "source available".  This update removes references to open source to avoid potential confusion.