### PR TITLE
docs: Update Contributor Guide

### DIFF
--- a/docs/guide-general.rst
+++ b/docs/guide-general.rst
@@ -221,6 +221,13 @@ git branch -d newfeature
 ```
 
 
+Creating A New Repository
+=========================
+
+For some contributions it may be required to create a new Curve repository. The `Curve repositories <https://github.com/curvefi>`_ aim to employ a consistent code style. In order to make new repositories adhere to this style, there exists a *Curve repository template*, which should be used.
+
+The template repository can be found `here <https://github.com/curvefi/curve-base-repo>`_. This template already contains dependencies and formatting rules in line with the Curve style guidelines.
+
 
 **Copyright**
 


### PR DESCRIPTION
## What I did

Add link to [Curve repo template](https://github.com/curvefi/curve-base-repo) in contributor docs. Encouraging new Curve repos to be based on this template will hopefully circumvent linting and code style nightmares down the road.