### PR TITLE
Add Curve Pool docs to StableSwap Exchange docs

### DIFF
--- a/docs/dao-fees.rst
+++ b/docs/dao-fees.rst
@@ -6,7 +6,7 @@ Curve DAO: Fee Collection and Distribution
 
 Curve exchange contracts have the capability to charge an "admin fee", claimable by the contract owner. The admin fee is represented as a percentage of the total fee collected on a swap.
 
-For exchanges the fee is taken in the output currency and calculated againt the final amount received. For example, if swapping from USDT to USDC, the fee is taken in USDC.
+For exchanges the fee is taken in the output currency and calculated against the final amount received. For example, if swapping from USDT to USDC, the fee is taken in USDC.
 
 Liquidity providers also incur fees when adding or removing liquidity. The fee is applied such that, for example, a swap between USDC and USDT would pay roughly the same amount of fees as depositing USDC into the pool and then withdrawing USDT. The only case where a fee is not applied on withdrawal is when removing liquidity via :ref:`remove_liquidity<StableSwap.remove_liquidity>`, as this method does not change the imbalance of the pool in any way.
 

--- a/docs/dao-overview.rst
+++ b/docs/dao-overview.rst
@@ -1,8 +1,8 @@
 .. _dao-overview:
 
-=======================
-The Curve DAO: Overview
-=======================
+=============
+The Curve DAO
+=============
 
 Curve DAO consists of multiple smart contracts connected by `Aragon <https://github.com/aragon/aragonOS>`_. Interaction with Aragon occurs through a `modified implementation <https://github.com/curvefi/curve-aragon-voting>`_ of the `Aragon Voting App <https://github.com/aragon/aragon-apps/tree/master/apps/voting>`_. Aragon's standard one token, one vote method is replaced with a weighting system based on locking tokens.
 

--- a/docs/exchange-deposits.rst
+++ b/docs/exchange-deposits.rst
@@ -11,19 +11,18 @@ Curve StableSwap Exchange: Deposit Contracts
 Lending Pool Deposits
 =====================
 
-While Curve lending pools support swaps in both the wrapped *and* underlying coins, not all lending pools allow liquidity providers to deposit and/or withdraw the underlying coin.
+While Curve lending pools support swaps in both the wrapped *and* underlying coins, not all lending pools allow liquidity providers to deposit or withdraw the underlying coin.
 
-For example, the Compound Pool allows swaps between ``cDai`` and ``cUSDC`` (wrapped coins), as well as swaps between ``DAI`` and ``USDC`` (underlying coins). However, liquidity providers are not able to deposit ``DAI`` or ``USDC`` to the pool directly.
-The main reason for why this is not supported by all Curve lending pools lies in the maximum byte code size of contracts. Lending pools may handle different degrees of complexity and can therefore end up being very close to the contract byte code size limit.
+For example, the Compound Pool allows swaps between ``cDai`` and ``cUSDC`` (wrapped coins), as well as swaps between ``DAI`` and ``USDC`` (underlying coins). However, liquidity providers are not able to deposit ``DAI`` or ``USDC`` to the pool directly. The main reason for why this is not supported by all Curve lending pools lies in the `size limit of contracts <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md>`_. Lending pools may differ in complexity and can end up being very close to the contract byte code size limit. In order to overcome this restriction, liquidity can be added and removed to and from a lending pool in the underlying coins via a different contract, called a *deposit zap*, tailored to lending pools.
 
 For an overview of the Curve lending pool implementation, please refer to the :ref:`Lending Pool <exchange-pools-lending>` section.
 
-The template source code for a lending pool deposit "zap" may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_.
+The template source code for a lending pool deposit zap may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_.
 
-Deposit Zap API (v1)
+Deposit Zap API (OLD)
 --------------------
 
-Older Curve lending pool deposit zaps do not implement the `template API (v2) <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_. The deposit zaps which employ an older API (v1) are:
+Older Curve lending pool deposit zaps do not implement the `template API <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_. The deposit zaps which employ an older API are:
 
     * ``DepositBUSD``: `BUSD pool deposit zap <https://etherscan.io/address/0xb6c057591e073249f2d9d88ba59a46cfc9b59edb#code>`_
     * ``DepositCompound``: `Compound pool deposit zap <https://etherscan.io/address/0xeb21209ae4c2c9ff2a86aca31e123764a3b6bc06#code>`_
@@ -31,7 +30,7 @@ Older Curve lending pool deposit zaps do not implement the `template API (v2) <h
     * ``DepositUSDT``: `USDT pool deposit zap <https://etherscan.io/address/0xac795d2c97e60df6a99ff1c814727302fd747a80#code>`_
     * ``DepositY``: `Y pool deposit zap <https://etherscan.io/address/0xbbc81d23ea2c3ec7e56d39296f0cbb648873a5d3#readContract>`_
 
-While not a lending pool, note that the following contract also implements the v1 deposit zap API:
+While not a lending pool, note that the following contract also implements the newer deposit zap API:
 
     * ``DepositSUSD``: `SUSD pool deposit zap <https://etherscan.io/address/0xfcba3e75865d2d561be8d220616520c171f12851#code>`_
 
@@ -46,7 +45,7 @@ The following Brownie console interaction examples are using the `Compound Pool 
 
 .. py:function:: DepositZap.curve() -> address: view
 
-    Getter for the Curve pool associated with this deposit contract.
+    Getter for the pool associated with this deposit contract.
 
     .. code-block:: python
 
@@ -81,7 +80,7 @@ The following Brownie console interaction examples are using the `Compound Pool 
 
 .. py:function:: DepositZap.token() -> address: view
 
-    Getter for the LP token of the associated Curve pool.
+    Getter for the LP token of the associated pool.
 
     .. code-block:: python
 
@@ -97,7 +96,7 @@ Adding/Removing Liquidity
     Wrap underlying coins and deposit them in the pool
 
     * ``uamounts``: List of amounts of underlying coins to deposit
-    * ``min_mint_amount``: Minimum amount of LP tokens to mint from the deposit
+    * ``min_mint_amount``: Minimum amount of LP token to mint from the deposit
 
 .. py:function:: DepositZap.remove_liquidity(_amount: uint256, min_uamounts: uint256[N_COINS])
 
@@ -131,7 +130,7 @@ Adding/Removing Liquidity
 
 .. py:function:: DepositZap.withdraw_donated_dust()
 
-    Donates any LP tokens of the associated Curve pool held by this contract to the contract owner.
+    Donates any LP tokens of the associated pool held by this contract to the contract owner.
 
 
 Deposit Zap API (v2)
@@ -144,7 +143,7 @@ Get Deposit Zap information
 
 .. py:function:: DepositZap.curve() -> address: view
 
-    Getter for the Curve pool associated with this deposit contract.
+    Getter for the pool associated with this deposit contract.
 
 .. py:function:: DepositZap.underlying_coins(i: uint256) -> address: view
 
@@ -160,7 +159,7 @@ Get Deposit Zap information
 
 .. py:function:: DepositZap.lp_token() -> address: view
 
-    Getter for the LP token of the associated Curve pool.
+    Getter for the LP token of the associated pool.
 
 
 Adding/Removing Liquidity
@@ -173,7 +172,7 @@ Adding/Removing Liquidity
     * ``_underlying_amounts``: List of amounts of underlying coins to deposit
     * ``_min_mint_amount``: Minimum amount of LP tokens to mint from the deposit
 
-    Returns the amount of LP tokens received in exchange for the deposited amounts.
+    Returns the amount of LP token received in exchange for the deposited amounts.
 
 .. py:function:: DepositZap.remove_liquidity(_amount: uint256, _min_underlying_amounts: uint256[N_COINS]) -> uint256[N_COINS]
 
@@ -209,6 +208,110 @@ Adding/Removing Liquidity
 Metapool Deposits
 =================
 
+While Curve metapools support swaps between base pool coins, the base pool LP token and metapool coins, they do not allow liquidity providers to deposit and/or withdraw base pool coins.
 
+For example, the GUSD metapool is a pool consisting of ``GUSD`` and ``3CRV`` (the LP token of the 3CRV pool) and allows for swaps between ``GUSD``, ``DAI``, ``USDC``, ``USDT`` and ``3CRV`` (wrapped coins). However, liquidity providers are not able to deposit ``DAI``, ``USDC`` or ``USDT`` to the pool directly. The main reason why this is not possible lies in the maximum byte code size of contracts. Metapools are complex and can therefore end up being very close to the contract byte code size limit. In order to overcome this restriction, liquidity can be added and removed to and from a metapool in the base pool's coins through a metapool deposit zap.
+
+For an overview of the Curve metapool implementation, please refer to the :ref:`Metapool <exchange-pools-meta>` section.
 
 The template source code for a metapool deposit "zap" may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/meta/DepositTemplateMeta.vy>`_.
+
+A list of all deployed metapool deposit zaps can be found :ref:`here <addresses-metapools>`.
+
+.. note::
+    Metapool deposit zaps contain the following private and hardcoded constants:
+
+    * ``N_COINS``: Number of coins in the metapool (excluding base pool coins)
+    * ``BASE_N_COINS``: Number of coins in the base pool
+    * ``N_ALL_COINS``: All coins in the metapool, excluding the base pool LP token (``N_COINS + BASE_N_COINS - 1``)
+
+
+Get Deposit Zap information
+---------------------------
+
+.. py:function:: DepositZap.pool() -> address: view
+
+    Getter for the metapool associated with this deposit contract.
+
+.. py:function:: DepositZap.base_pool() -> address: view
+
+    Getter for the base pool of the metapool associated with this deposit contract.
+
+.. py:function:: DepositZap.base_coins(i: uint256) -> address: view
+
+    Getter for the array of the coins of the metapool's base pool.
+
+    * ``i``: Index of the underlying coin for which to get the address
+
+.. py:function:: DepositZap.coins(i: uint256) -> address: view
+
+    Getter for the array of metapool's coins.
+
+    * ``i``: Index of the coin for which to get the address
+
+.. py:function:: DepositZap.token() -> address: view
+
+    Getter for the LP token of the associated metapool.
+
+
+Adding/Removing Liquidity
+-------------------------
+
+.. note::
+    For methods taking the index argument ``i``, a number in the range from ``0`` to ``N_ALL_COINS - 1`` is valid. This refers to all coins apart from the base pool LP token.
+
+.. py:function:: DepositZap.add_liquidity(_amounts: uint256[N_ALL_COINS], _min_mint_amount: uint256) -> uint256
+
+    Wrap underlying coins and deposit them in the pool.
+
+    * ``_amounts``: List of amounts of underlying coins to deposit
+    * ``_min_mint_amount``: Minimum amount of LP tokens to mint from the deposit
+
+    Returns the amount of LP token received in exchange for depositing.
+
+.. py:function:: DepositZap.remove_liquidity(_amount: uint256, _min_amounts: uint256[N_ALL_COINS]) -> uint256[N_ALL_COINS]
+
+    Withdraw and unwrap coins from the pool.
+
+    * ``_amount``: Quantity of LP tokens to burn in the withdrawal
+    * ``_min_amounts``: Minimum amounts of underlying coins to receive
+
+    Returns a list of amounts of underlying coins that were withdrawn.
+
+.. py:function:: DepositZap.remove_liquidity_one_coin(_token_amount: uint256, i: int128, _min_amount: uint256) -> uint256
+
+    Withdraw and unwrap a single coin from the metapool.
+
+    * ``_token_amount``: Amount of LP tokens to burn in the withdrawal
+    * ``i``: Index value of the coin to withdraw
+    * ``_min_amount``: Minimum amount of underlying coin to receive
+
+    Returns the amount of the underlying coin received.
+
+.. py:function:: DepositZap.remove_liquidity_imbalance(_amounts: uint256[N_ALL_COINS], _max_burn_amount: uint256) -> uint256
+
+    Withdraw coins from the pool in an imbalanced amount
+
+    * ``_amounts``: List of amounts of underlying coins to withdraw
+    * ``_max_burn_amount``: Maximum amount of LP token to burn in the withdrawal
+
+    Returns the actual amount of the LP token burned in the withdrawal.
+
+.. py:function:: DepositZap.calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256
+
+    Calculate the amount received when withdrawing and unwrapping a single coin
+
+    * ``_token_amount``: Amount of LP tokens to burn in the withdrawal
+    * ``i``: Index value of the coin to withdraw (``i`` should be in the range from ``0`` to ``N_ALL_COINS - 1``, where the LP token of the base pool is removed).
+
+    Returns the amount of coin ``i`` received.
+
+.. py:function:: DepositZap.calc_token_amount(_amounts: uint256[N_ALL_COINS], _is_deposit: bool) -> uint256
+
+    Calculate addition or reduction in token supply from a deposit or withdrawal.
+
+    * ``_amounts``: Amount of each underlying coin being deposited
+    * ``_is_deposit``: Set True for deposits, False for withdrawals
+
+    Returns the expected amount of LP tokens received.
+

--- a/docs/exchange-deposits.rst
+++ b/docs/exchange-deposits.rst
@@ -3,3 +3,212 @@
 ============================================
 Curve StableSwap Exchange: Deposit Contracts
 ============================================
+
+.. note::
+    Curve Deposit Zaps may differ in their API. Older pools do not implement the newer API templates for `lending <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_ and `metapool <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/meta/DepositTemplateMeta.vy>`_ deposit zaps.
+
+
+Lending Pool Deposits
+=====================
+
+While Curve lending pools support swaps in both the wrapped *and* underlying coins, not all lending pools allow liquidity providers to deposit and/or withdraw the underlying coin.
+
+For example, the Compound Pool allows swaps between ``cDai`` and ``cUSDC`` (wrapped coins), as well as swaps between ``DAI`` and ``USDC`` (underlying coins). However, liquidity providers are not able to deposit ``DAI`` or ``USDC`` to the pool directly.
+The main reason for why this is not supported by all Curve lending pools lies in the maximum byte code size of contracts. Lending pools may handle different degrees of complexity and can therefore end up being very close to the contract byte code size limit.
+
+For an overview of the Curve lending pool implementation, please refer to the :ref:`Lending Pool <exchange-pools-lending>` section.
+
+The template source code for a lending pool deposit "zap" may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_.
+
+Deposit Zap API (v1)
+--------------------
+
+Older Curve lending pool deposit zaps do not implement the `template API (v2) <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_. The deposit zaps which employ an older API (v1) are:
+
+    * ``DepositBUSD``: `BUSD pool deposit zap <https://etherscan.io/address/0xb6c057591e073249f2d9d88ba59a46cfc9b59edb#code>`_
+    * ``DepositCompound``: `Compound pool deposit zap <https://etherscan.io/address/0xeb21209ae4c2c9ff2a86aca31e123764a3b6bc06#code>`_
+    * ``DepositPAX``: `PAX pool deposit zap <https://etherscan.io/address/0xa50ccc70b6a011cffddf45057e39679379187287#code>`_
+    * ``DepositUSDT``: `USDT pool deposit zap <https://etherscan.io/address/0xac795d2c97e60df6a99ff1c814727302fd747a80#code>`_
+    * ``DepositY``: `Y pool deposit zap <https://etherscan.io/address/0xbbc81d23ea2c3ec7e56d39296f0cbb648873a5d3#readContract>`_
+
+While not a lending pool, note that the following contract also implements the v1 deposit zap API:
+
+    * ``DepositSUSD``: `SUSD pool deposit zap <https://etherscan.io/address/0xfcba3e75865d2d561be8d220616520c171f12851#code>`_
+
+
+Get Deposit Zap information
+***************************
+
+.. note::
+    Getters generated for public arrays changed between Vyper ``0.1.x`` and ``0.2.x`` to accept ``uint256`` instead of ``int128`` in order to handle the lookups. Older deposit zap contracts (v1) use ``vyper 0.1.x...``, while newer zaps (v2) use ``vyper 0.2.x...``.
+
+The following Brownie console interaction examples are using the `Compound Pool Deposit Zap <https://etherscan.io/address/0xeb21209ae4c2c9ff2a86aca31e123764a3b6bc06>`_.
+
+.. py:function:: DepositZap.curve() -> address: view
+
+    Getter for the Curve pool associated with this deposit contract.
+
+    .. code-block:: python
+
+        >>> zap.curve()
+        '0xA2B47E3D5c44877cca798226B7B8118F9BFb7A56'
+
+.. py:function:: DepositZap.underlying_coins(i: int128) -> address: view
+
+    Getter for the array of **underlying** coins within the associated pool.
+
+    * ``i``: Index of the underlying coin for which to get the address
+
+    .. code-block:: python
+
+        >>> zap.underlying_coins(0)
+        '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+        >>> zap.underlying_coins(1)
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+
+.. py:function:: DepositZap.coins(i: int128) -> address: view
+
+    Getter for the array of **wrapped** coins within the associated pool.
+
+    * ``i``: Index of the coin for which to get the address
+
+    .. code-block:: python
+
+        >>> zap.coins(0)
+        '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643'
+        >>> zap.coins(1)
+        '0x39AA39c021dfbaE8faC545936693aC917d5E7563'
+
+.. py:function:: DepositZap.token() -> address: view
+
+    Getter for the LP token of the associated Curve pool.
+
+    .. code-block:: python
+
+        >>> zap.token()
+        '0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2'
+
+
+Adding/Removing Liquidity
+*************************
+
+.. py:function:: DepositZap.add_liquidity(uamounts: uint256[N_COINS], min_mint_amount: uint256)
+
+    Wrap underlying coins and deposit them in the pool
+
+    * ``uamounts``: List of amounts of underlying coins to deposit
+    * ``min_mint_amount``: Minimum amount of LP tokens to mint from the deposit
+
+.. py:function:: DepositZap.remove_liquidity(_amount: uint256, min_uamounts: uint256[N_COINS])
+
+    Withdraw and unwrap coins from the pool.
+
+    * ``_amount``: Quantity of LP tokens to burn in the withdrawal
+    * ``min_uamounts``: Minimum amounts of underlying coins to receive
+
+.. py:function:: DepositZap.remove_liquidity_imbalance(uamounts: uint256[N_COINS], max_burn_amount: uint256)
+
+    Withdraw and unwrap coins from the pool in an imbalanced amount.
+
+    * ``uamounts``: List of amounts of underlying coins to withdraw
+    * ``max_burn_amount``: Maximum amount of LP token to burn in the withdrawal
+
+.. py:function:: DepositZap.remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_uamount: uint256, donate_dust: bool = False)
+
+    Withdraw and unwrap a single coin from the pool
+
+    * ``_token_amount``: Amount of LP tokens to burn in the withdrawal
+    * ``i``: Index value of the coin to withdraw
+    * ``min_uamount``: Minimum amount of underlying coin to receive
+    * ``donate_dust``: Donates any dust if ``True``
+
+.. py:function:: DepositZap.calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256
+
+    Calculate the amount received when withdrawing a single underlying coin.
+
+    * ``_token_amount``: Amount of LP tokens to burn in the withdrawal
+    * ``i``: Index value of the coin to withdraw
+
+.. py:function:: DepositZap.withdraw_donated_dust()
+
+    Donates any LP tokens of the associated Curve pool held by this contract to the contract owner.
+
+
+Deposit Zap API (v2)
+--------------------
+
+Compared to the older deposit zaps, the newer zaps mainly optimize for gas efficiency. The API is only modified in part, specifically with regards to `return` values and variable naming.
+
+Get Deposit Zap information
+***************************
+
+.. py:function:: DepositZap.curve() -> address: view
+
+    Getter for the Curve pool associated with this deposit contract.
+
+.. py:function:: DepositZap.underlying_coins(i: uint256) -> address: view
+
+    Getter for the array of **underlying** coins within the associated pool.
+
+    * ``i``: Index of the underlying coin for which to get the address
+
+.. py:function:: DepositZap.coins(i: uint256) -> address: view
+
+    Getter for the array of **wrapped** coins within the associated pool.
+
+    * ``i``: Index of the coin for which to get the address
+
+.. py:function:: DepositZap.lp_token() -> address: view
+
+    Getter for the LP token of the associated Curve pool.
+
+
+Adding/Removing Liquidity
+*************************
+
+.. py:function:: DepositZap.add_liquidity(_underlying_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint256
+
+    Wrap underlying coins and deposit them in the pool
+
+    * ``_underlying_amounts``: List of amounts of underlying coins to deposit
+    * ``_min_mint_amount``: Minimum amount of LP tokens to mint from the deposit
+
+    Returns the amount of LP tokens received in exchange for the deposited amounts.
+
+.. py:function:: DepositZap.remove_liquidity(_amount: uint256, _min_underlying_amounts: uint256[N_COINS]) -> uint256[N_COINS]
+
+    Withdraw and unwrap coins from the pool.
+
+    * ``_amount``: Quantity of LP tokens to burn in the withdrawal
+    * ``_min_underlying_amounts``: Minimum amounts of underlying coins to receive
+
+    Returns list of amounts of underlying coins that were withdrawn.
+
+
+.. py:function:: DepositZap.remove_liquidity_imbalance(_underlying_amounts: uint256[N_COINS], _max_burn_amount: uint256) -> uint256[N_COINS]
+
+    Withdraw and unwrap coins from the pool in an imbalanced amount. Amounts in `_underlying_amounts` correspond to withdrawn amounts before any fees charge for unwrapping.
+
+    * ``_underlying_amounts``: List of amounts of underlying coins to withdraw
+    * ``_max_burn_amount``: Maximum amount of LP token to burn in the withdrawal
+
+    Returns list of amounts of underlying coins that were withdrawn.
+
+
+.. py:function:: DepositZap.remove_liquidity_one_coin(_amount: uint256, i: int128, _min_underlying_amount: uint256) -> uint256
+
+    Withdraw and unwrap a single coin from the pool
+
+    * ``_amount``: Amount of LP tokens to burn in the withdrawal
+    * ``i``: Index value of the coin to withdraw
+    * ``_min_underlying_amount``: Minimum amount of underlying coin to receive
+
+    Returns amount of underlying coin received.
+
+
+Metapool Deposits
+=================
+
+
+
+The template source code for a metapool deposit "zap" may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/meta/DepositTemplateMeta.vy>`_.

--- a/docs/exchange-deposits.rst
+++ b/docs/exchange-deposits.rst
@@ -4,9 +4,7 @@
 Curve StableSwap Exchange: Deposit Contracts
 ============================================
 
-.. note::
-    Curve Deposit Zaps may differ in their API. Older pools do not implement the newer API templates for `lending <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_ and `metapool <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/meta/DepositTemplateMeta.vy>`_ deposit zaps.
-
+Curve pools may rely on a different contract, called a *deposit zap* for the addition and removal of underlying coins. This is particularly useful for lending pools, which may only support the addition/removal of wrapped coins. Furthermore, deposit zaps are also useful for metapools, which do not support the addition/removal of base pool coins.
 
 Lending Pool Deposits
 =====================
@@ -18,6 +16,11 @@ For example, the Compound Pool allows swaps between ``cDai`` and ``cUSDC`` (wrap
 For an overview of the Curve lending pool implementation, please refer to the :ref:`Lending Pool <exchange-pools-lending>` section.
 
 The template source code for a lending pool deposit zap may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_.
+
+
+.. note::
+    Lending pool deposit zaps may differ in their API. Older pools do not implement the newer API templates for `lending <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>` deposit zaps.
+
 
 Deposit Zap API (OLD)
 --------------------
@@ -35,7 +38,7 @@ While not a lending pool, note that the following contract also implements the n
     * ``DepositSUSD``: `SUSD pool deposit zap <https://etherscan.io/address/0xfcba3e75865d2d561be8d220616520c171f12851#code>`_
 
 
-Get Deposit Zap information
+Get Deposit Zap Information
 ***************************
 
 .. note::
@@ -133,12 +136,12 @@ Adding/Removing Liquidity
     Donates any LP tokens of the associated pool held by this contract to the contract owner.
 
 
-Deposit Zap API (v2)
+Deposit Zap API (NEW)
 --------------------
 
-Compared to the older deposit zaps, the newer zaps mainly optimize for gas efficiency. The API is only modified in part, specifically with regards to `return` values and variable naming.
+Compared to the older deposit zaps, the newer zaps mainly optimize for gas efficiency. The API is only modified in part, specifically with regards to ``return`` values and variable naming.
 
-Get Deposit Zap information
+Get Deposit Zap Information
 ***************************
 
 .. py:function:: DepositZap.curve() -> address: view
@@ -210,7 +213,7 @@ Metapool Deposits
 
 While Curve metapools support swaps between base pool coins, the base pool LP token and metapool coins, they do not allow liquidity providers to deposit and/or withdraw base pool coins.
 
-For example, the GUSD metapool is a pool consisting of ``GUSD`` and ``3CRV`` (the LP token of the 3CRV pool) and allows for swaps between ``GUSD``, ``DAI``, ``USDC``, ``USDT`` and ``3CRV`` (wrapped coins). However, liquidity providers are not able to deposit ``DAI``, ``USDC`` or ``USDT`` to the pool directly. The main reason why this is not possible lies in the maximum byte code size of contracts. Metapools are complex and can therefore end up being very close to the contract byte code size limit. In order to overcome this restriction, liquidity can be added and removed to and from a metapool in the base pool's coins through a metapool deposit zap.
+For example, the GUSD metapool is a pool consisting of ``GUSD`` and ``3CRV`` (the LP token of the 3Pool) and allows for swaps between ``GUSD``, ``DAI``, ``USDC``, ``USDT`` and ``3CRV``. However, liquidity providers are not able to deposit ``DAI``, ``USDC`` or ``USDT`` to the pool directly. The main reason why this is not possible lies in the maximum byte code size of contracts. Metapools are complex and can therefore end up being very close to the contract byte code size limit. In order to overcome this restriction, liquidity can be added and removed to and from a metapool in the base pool's coins through a metapool deposit zap.
 
 For an overview of the Curve metapool implementation, please refer to the :ref:`Metapool <exchange-pools-meta>` section.
 
@@ -226,7 +229,7 @@ A list of all deployed metapool deposit zaps can be found :ref:`here <addresses-
     * ``N_ALL_COINS``: All coins in the metapool, excluding the base pool LP token (``N_COINS + BASE_N_COINS - 1``)
 
 
-Get Deposit Zap information
+Get Deposit Zap Information
 ---------------------------
 
 .. py:function:: DepositZap.pool() -> address: view

--- a/docs/exchange-deposits.rst
+++ b/docs/exchange-deposits.rst
@@ -19,7 +19,7 @@ The template source code for a lending pool deposit zap may be viewed on `GitHub
 
 
 .. note::
-    Lending pool deposit zaps may differ in their API. Older pools do not implement the newer API templates for `lending <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>` deposit zaps.
+    Lending pool deposit zaps may differ in their API. Older pools do not implement the newer `API template <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/y/DepositTemplateY.vy>`_.
 
 
 Deposit Zap API (OLD)
@@ -122,7 +122,6 @@ Adding/Removing Liquidity
     * ``_token_amount``: Amount of LP tokens to burn in the withdrawal
     * ``i``: Index value of the coin to withdraw
     * ``min_uamount``: Minimum amount of underlying coin to receive
-    * ``donate_dust``: Donates any dust if ``True``
 
 .. py:function:: DepositZap.calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256
 

--- a/docs/exchange-lp-tokens.rst
+++ b/docs/exchange-lp-tokens.rst
@@ -4,9 +4,7 @@
 Curve StableSwap Exchange: LP Tokens
 ====================================
 
-In exchange for depositing coins into a Curve pool (see :ref:`Curve Pools <exchange-pools>`), liquidity providers receive pool LP tokens. A Curve pool LP token is an ERC20 contract specific to the Curve pool. Hence, LP tokens are transferrable. Holders of pool LP tokens may stake the token into a pool's :ref:`liquidity gauge <dao-gauges>` in order to receive ``CRV`` token rewards. Alternatively, if the LP token is supported by a metapool, the token may be deposited into the respective metapool in exchange for the metapool's LP token.
-
-For example, a liquidity provider may deposit ``DAI`` into 3Pool and in exchange receive the pool's LP token ``3CRV``. The ``3CRV`` LP token may then be deposited into the GUSD metapool, which contains the coins ``GUSD`` and ``3CRV``, in exchange for the metapool's LP token ``gusd3CRV``. The obtained LP token may then be staked in the metapool's liquidity gauge.
+In exchange for depositing coins into a Curve pool (see :ref:`Curve Pools <exchange-pools>`), liquidity providers receive pool LP tokens. A Curve pool LP token is an ERC20 contract specific to the Curve pool. Hence, LP tokens are transferrable. Holders of pool LP tokens may stake the token into a pool's :ref:`liquidity gauge <dao-gauges>` in order to receive ``CRV`` token rewards. Alternatively, if the LP token is supported by a metapool, the token may be deposited into the respective metapool in exchange for the metapool's LP token (see :ref:`here <exchange-pools-meta>`).
 
 The following versions of Curve pool LP tokens exist:
 

--- a/docs/exchange-lp-tokens.rst
+++ b/docs/exchange-lp-tokens.rst
@@ -64,9 +64,10 @@ The implementation for a Curve Token V1 may be viewed on `GitHub <https://github
 
 
 .. py:function:: CurveToken.totalSupply() -> uint256: view
-    .. code-block:: python
 
     Get the total token supply.
+
+    .. code-block:: python
 
         >>> lp_token.totalSupply()
         73112516629065063732935484
@@ -113,6 +114,9 @@ The implementation for a Curve Token V1 may be viewed on `GitHub <https://github
     * ``_value``: Amount of tokens to be spent.
 
     Returns ``True`` if approval succeeded.
+
+    .. warning::
+        For Curve LP Tokens V1 and V2, **non-zero to non-zero approvals are prohibited**. Instead, after every non-zero approval, the allowance for the spender **must** be reset to ``0``.
 
 
 Minter Methods
@@ -166,6 +170,9 @@ The implementation for a Curve Token V2 may be viewed on `GitHub <https://github
         * ``mint`` method returns ``bool``
         * ``burnFrom`` method returns ``bool``
         * ``burn`` method has been removed
+
+.. warning::
+    For Curve LP Tokens V1 and V2, **non-zero to non-zero approvals are prohibited**. Instead, after every non-zero approval, the allowance for the spender **must** be reset to ``0``.
 
 
 .. py:function:: CurveToken.minter() -> address: view

--- a/docs/exchange-lp-tokens.rst
+++ b/docs/exchange-lp-tokens.rst
@@ -12,14 +12,12 @@ The following versions of Curve pool LP tokens exist:
 
 * `CurveTokenV1 <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV1.vy>`_: LP token targetting Vyper `^0.1.0-beta.16 <https://vyper.readthedocs.io/en/stable/release-notes.html#v0-1-0-beta-16>`_
 * `CurveTokenV2 <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV2.vy>`_: LP token targetting Vyper `^0.2.0 <https://vyper.readthedocs.io/en/stable/release-notes.html#v0-2-1>`_
-* `CurveTokenV3 <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV3.vy>`_: LP token
+* `CurveTokenV3 <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV3.vy>`_: LP token targetting Vyper `^0.2.0 <https://vyper.readthedocs.io/en/stable/release-notes.html#v0-2-1>`_ with gas optimizations
 
 The version of each pool's LP token can be found in the :ref:`Deployment Addresses <addresses-overview>`.
 
 .. note::
     For older Curve pools the ``token`` attribute is not always ``public`` and a getter has not been explicitly implemented.
-
-
 
 
 Curve Token V1
@@ -162,13 +160,15 @@ Curve Token V2
 
 The implementation for a Curve Token V2 may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV2.vy>`_.
 
-Compared to Curve Token v1, the following changes have been made to the API:
+.. note::
+    Compared to Curve Token v1, the following changes have been made to the API:
 
-    * ``minter`` attribute is ``public`` and therefore a minter getter has been generated
-    * ``name`` and ``symbol`` attributes can be set via ``set_name``
-    * ``mint`` method returns ``bool``
-    * ``burnFrom`` method returns ``bool``
-    * ``burn`` method has been removed
+        * ``minter`` attribute is ``public`` and therefore a minter getter has been generated
+        * ``name`` and ``symbol`` attributes can be set via ``set_name``
+        * ``mint`` method returns ``bool``
+        * ``burnFrom`` method returns ``bool``
+        * ``burn`` method has been removed
+
 
 .. py:function:: CurveToken.minter() -> address: view
 
@@ -205,4 +205,35 @@ Compared to Curve Token v1, the following changes have been made to the API:
 Curve Token V3
 ==============
 
+The Curve Token V3 is more gas efficient than versions 1 and 2.
+
+.. note::
+    Compared to the Curve Token V2 API, there have been the following changes:
+
+    * ``increaseAllowance`` and ``decreaseAllowance`` methods added to mitigate race conditions
+
 The implementation for a Curve Token V3 may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV3.vy>`_.
+
+
+.. py:function:: CurveToken.increaseAllowance(_spender: address, _added_value: uint256) -> bool
+
+    Increase the allowance granted to ``_spender`` by the ``msg.sender``.
+
+    This is alternative to ``approve`` that can be used as a mitigation for the potential race condition.
+
+    * ``_spender``: Address which will transfer the funds
+    * ``_added_value``: Amount of to increase the allowance
+
+    Returns ``True`` if success.
+
+
+.. py:function:: CurveToken.decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool
+
+    Decrease the allowance granted to ``_spender`` by the ``msg.sender``.
+
+    This is alternative to {approve} that can be used as a mitigation for the potential race condition.
+
+    * ``_spender``: Address which will transfer the funds
+    * ``_subtracted_value``: Amount of to decrease the allowance
+
+    Returns ``True`` if success.

--- a/docs/exchange-lp-tokens.rst
+++ b/docs/exchange-lp-tokens.rst
@@ -3,3 +3,206 @@
 ====================================
 Curve StableSwap Exchange: LP Tokens
 ====================================
+
+In exchange for depositing coins into a Curve pool (see :ref:`Curve Pools <exchange-pools>`), liquidity providers receive pool LP tokens. A Curve pool LP token is an ERC20 contract specific to the Curve pool. Hence, LP tokens are transferrable. Holders of pool LP tokens may stake the token into a pool's :ref:`liquidity gauge <dao-gauges>` in order to receive ``CRV`` token rewards. Alternatively, if the LP token is supported by a metapool, the token may be deposited into the respective metapool in exchange for the metapool's LP token.
+
+For example, a liquidity provider may deposit ``DAI`` into 3Pool and in exchange receive the pool's LP token ``3CRV``. The ``3CRV`` LP token may then be deposited into the GUSD metapool, which contains the coins ``GUSD`` and ``3CRV``, in exchange for the metapool's LP token ``gusd3CRV``. The obtained LP token may then be staked in the metapool's liquidity gauge.
+
+The following versions of Curve pool LP tokens exist:
+
+* `CurveTokenV1 <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV1.vy>`_: LP token targetting Vyper `^0.1.0-beta.16 <https://vyper.readthedocs.io/en/stable/release-notes.html#v0-1-0-beta-16>`_
+* `CurveTokenV2 <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV2.vy>`_: LP token targetting Vyper `^0.2.0 <https://vyper.readthedocs.io/en/stable/release-notes.html#v0-2-1>`_
+* `CurveTokenV3 <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV3.vy>`_: LP token
+
+The version of each pool's LP token can be found in the :ref:`Deployment Addresses <addresses-overview>`.
+
+.. note::
+    For older Curve pools the ``token`` attribute is not always ``public`` and a getter has not been explicitly implemented.
+
+
+
+
+Curve Token V1
+==============
+
+The implementation for a Curve Token V1 may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV1.vy>`_.
+
+.. py:function:: CurveToken.name() -> string[64]: view
+
+    Get the name of the token.
+
+    .. code-block:: python
+
+        >>> lp_token.name()
+        'Curve.fi yDAI/yUSDC/yUSDT/yBUSD'
+
+
+.. py:function:: CurveToken.symbol() -> string[32]: view
+
+    Get the token symbol.
+
+    .. code-block:: python
+
+        >>> lp_token.symbol()
+        'yDAI+yUSDC+yUSDT+yBUSD'
+
+.. py:function:: CurveToken.decimals() -> uint256: view
+
+    Get the number of decimals for the token.
+
+    .. code-block:: python
+
+        >>> lp_token.decimals()
+        18
+
+.. py:function:: CurveToken.balanceOf(account: address) -> uint256: view
+
+    Get the token balance for an account.
+
+    * ``account``: Address to get the token balance for
+
+    .. code-block:: python
+
+        >>> lp_token.balanceOf("0x69fb7c45726cfe2badee8317005d3f94be838840")
+        72372801850459006740117197
+
+
+.. py:function:: CurveToken.totalSupply() -> uint256: view
+    .. code-block:: python
+
+    Get the total token supply.
+
+        >>> lp_token.totalSupply()
+        73112516629065063732935484
+
+
+.. py:function:: CurveToken.allowance(_owner : address, _spender : address) -> uint256: view
+
+    Get the allowance of an account to spend on behalf of some other account.
+
+    * ``_owner``: Account that is paying when ``_spender`` spends the allowance
+    * ``_spender``: Account that can spend up to the allowance
+
+    Returns the allowance of ``_spender`` for ``_owner``.
+
+
+.. py:function:: CurveToken.transfer(_to : address, _value : uint256) -> bool
+
+    Transfer tokens to a specified address.
+
+    * ``_to``: Receiver of the tokens
+    * ``_value``: Amount of tokens to transfer
+
+    Returns ``True`` if the transfer succeeded.
+
+
+.. py:function:: CurveToken.transferFrom(_from : address, _to : address, _value : uint256) -> bool
+
+    Transfer tokens from one address to another. Note that while this function emits a Transfer event, this is not required as per the specification, and other compliant implementations may not emit the event.
+
+    * ``_from``: Address which you want to send tokens from
+    * ``_to``: Address which you want to transfer to
+    * ``_value``: Amount of tokens to be transferred
+
+    Returns ``True`` if transfer succeeded.
+
+
+.. py:function:: CurveToken.approve(_spender : address, _value : uint256) -> bool
+
+    Approve the passed address to spend the specified amount of tokens on behalf of ``msg.sender``.
+
+    Beware that changing an allowance with this method brings the risk that someone may use both the old and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards (see this `GitHub issue <https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729>`_).
+
+    * ``_spender``: Address which will spend the funds.
+    * ``_value``: Amount of tokens to be spent.
+
+    Returns ``True`` if approval succeeded.
+
+
+Minter Methods
+--------------
+
+The following methods are only callable by the ``minter`` (private attribute).
+
+.. note::
+    For Curve Token V1, the ``minter`` attribute is not ``public``.
+
+.. py:function:: CurveToken.mint(_to: address, _value: uint256)
+
+    Mint an amount of the token and assign it to an account. This encapsulates the modification of balances such that the proper events are emitted.
+
+    * ``_to``: Address that will receive the created tokens
+    * ``_value``: Amount that will be created
+
+
+.. py:function:: CurveToken.burn(_value: uint256)
+
+    Burn an amount of the token of ``msg.sender``.
+
+    * ``_value``: Token amount that will be burned
+
+
+.. py:function:: CurveToken.burnFrom(_to: address, _value: uint256)
+
+    Burn an amount of the token from a given account.
+
+    * ``_to``: Account whose tokens will be burned
+    * ``_value``: Amount that will be burned
+
+
+.. py:function:: CurveToken.set_minter(_minter: address)
+
+    Set a new minter for the token.
+
+    * ``_minter``: Address of the new minter
+
+
+Curve Token V2
+==============
+
+The implementation for a Curve Token V2 may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV2.vy>`_.
+
+Compared to Curve Token v1, the following changes have been made to the API:
+
+    * ``minter`` attribute is ``public`` and therefore a minter getter has been generated
+    * ``name`` and ``symbol`` attributes can be set via ``set_name``
+    * ``mint`` method returns ``bool``
+    * ``burnFrom`` method returns ``bool``
+    * ``burn`` method has been removed
+
+.. py:function:: CurveToken.minter() -> address: view
+
+    Getter for the address of the ``minter`` of the token.
+
+
+.. py:function:: CurveToken.set_name(_name: String[64], _symbol: String[32])
+
+    Set the name and symbol of the token.
+
+    * ``_name``: New name of token
+    * ``_symbol``: New symbol of token
+
+    This method can only be called by ``minter``.
+
+
+.. py:function:: CurveToken.mint(_to: address, _value: uint256) -> bool
+
+    Mint an amount of the token and assign it to an account. This encapsulates the modification of balances such that the proper events are emitted.
+
+    Returns ``True`` if not reverted.
+
+
+.. py:function:: CurveToken.burnFrom(_to: address, _value: uint256) -> bool
+
+    Burn an amount of the token from a given account.
+
+    * ``_to``: Account whose tokens will be burned
+    * ``_value``: Amount that will be burned
+
+    Returns ``True`` if not reverted.
+
+
+Curve Token V3
+==============
+
+The implementation for a Curve Token V3 may be viewed on `GitHub <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV3.vy>`_.

--- a/docs/exchange-overview.rst
+++ b/docs/exchange-overview.rst
@@ -3,3 +3,13 @@
 ===================================
 Curve StableSwap Exchange: Overview
 ===================================
+
+Curve achieves extremely efficient stablecoin trades by implementing the StableSwap invariant, which has significantly lower slippage for stablecoin trades than many other prominent invariants (e.g., constant-product). Note that in this context *stablecoins* refers to tokens that are stable representations of one another. This includes, for example, USD-pegged stablecoins (like DAI and USDC), but also ETH and sETH (synthetic ETH) or different versions of wrapped BTC. For a detailed overview of the StableSwap invariant design, please read the official `StableSwap whitepaper <>`_.
+
+A Curve pool is essentially a smart contracts that contains the implementation of the StableSwap invariant and therefore the logic for exchanging tokens. However, while all Curve pools implement the StableSwap invariant, they may come in different pool flavors.
+
+In its simplest form, a Curve pool is an implementation of the StableSwap invariant with 2 or more tokens, which can be referred to as a *plain pool*. Alternative and more complex pool flavors include pools with lending functionality, so-called *lending pools*, as well as *metapools*, which are pools that allow for the exchange of one or more tokens with the tokens of one or more underlying base pools.
+
+Curve also integrates with Synthetix to offer cross-asset swaps.
+
+All exchange functionality that Curve offers, as well as noteworthy implementation details, are explained in technical depth in this section.

--- a/docs/exchange-overview.rst
+++ b/docs/exchange-overview.rst
@@ -4,12 +4,12 @@
 Curve StableSwap Exchange: Overview
 ===================================
 
-Curve achieves extremely efficient stablecoin trades by implementing the StableSwap invariant, which has significantly lower slippage for stablecoin trades than many other prominent invariants (e.g., constant-product). Note that in this context *stablecoins* refers to tokens that are stable representations of one another. This includes, for example, USD-pegged stablecoins (like DAI and USDC), but also ETH and sETH (synthetic ETH) or different versions of wrapped BTC. For a detailed overview of the StableSwap invariant design, please read the official `StableSwap whitepaper <>`_.
+Curve achieves extremely efficient stablecoin trades by implementing the StableSwap invariant, which has significantly lower slippage for stablecoin trades than many other prominent invariants (e.g., constant-product). Note that in this context *stablecoins* refers to tokens that are stable representations of one another. This includes, for example, USD-pegged stablecoins (like DAI and USDC), but also ETH and sETH (synthetic ETH) or different versions of wrapped BTC. For a detailed overview of the StableSwap invariant design, please read the official `StableSwap whitepaper <https://curve.fi/files/stableswap-paper.pdf>`_.
 
-A Curve pool is essentially a smart contracts that contains the implementation of the StableSwap invariant and therefore the logic for exchanging tokens. However, while all Curve pools implement the StableSwap invariant, they may come in different pool flavors.
+A Curve pool is essentially a smart contract that implements the StableSwap invariant and therefore contains the logic for exchanging stable tokens. However, while all Curve pools implement the StableSwap invariant, they may come in different pool flavors.
 
 In its simplest form, a Curve pool is an implementation of the StableSwap invariant with 2 or more tokens, which can be referred to as a *plain pool*. Alternative and more complex pool flavors include pools with lending functionality, so-called *lending pools*, as well as *metapools*, which are pools that allow for the exchange of one or more tokens with the tokens of one or more underlying base pools.
 
 Curve also integrates with Synthetix to offer cross-asset swaps.
 
-All exchange functionality that Curve offers, as well as noteworthy implementation details, are explained in technical depth in this section.
+All exchange functionality that Curve supports, as well as noteworthy implementation details, are explained in technical depth in this section.

--- a/docs/exchange-pools.rst
+++ b/docs/exchange-pools.rst
@@ -471,6 +471,9 @@ Amplification Coefficient
 
 The amplification co-efficient (“A”) determines a pool’s tolerance for imbalance between the assets within it. A higher value means that trades will incur slippage sooner as the assets within the pool become imbalanced.
 
+.. note::
+     Within the pools, ``A`` is in fact implemented as ``1 / A`` and therefore a higher value implies that the pool will be **more** tolerant to slippage when imbalanced.
+
 The appropriate value for A is dependent upon the type of coin being used within the pool.
 
 It is possible to modify the amplification coefficient for a pool after it has been deployed. However, it requires a vote within the Curve DAO and must reach a 15% quorum.
@@ -546,6 +549,9 @@ Kill a Pool
     * ``remove_liquidity_one_coin``
 
     Hence, when paused, it is only possible for existing LPs to remove liquidity via ``remove_liquidity``.
+
+    .. note::
+        Pools can only be killed within the first 30 days after deployment.
 
 .. py:function:: StableSwap.unkill_me()
 

--- a/docs/exchange-pools.rst
+++ b/docs/exchange-pools.rst
@@ -306,10 +306,13 @@ Some newer pools (e.g., `IB <https://github.com/curvefi/curve-contract/blob/mast
 
     * ``_amounts``: List of amounts of coins to deposit
     * ``_min_mint_amount``: Minimum amount of LP tokens to mint from the deposit
-    * ``_use_underlying`` If ``True`, deposit underlying assets instead of wrapped assets.
+    * ``_use_underlying`` If ``True``, deposit underlying assets instead of wrapped assets.
 
     Returns amount of LP tokens received in exchange for the deposited tokens.
 
+
+
+.. _exchange-pools-meta:
 
 Metapools
 =========

--- a/docs/exchange-pools.rst
+++ b/docs/exchange-pools.rst
@@ -3,3 +3,351 @@
 =======================
 Curve StableSwap: Pools
 =======================
+
+A Curve pool is a smart contract that implements the StableSwap invariant and thereby allows for the exchange of two tokens.
+
+More broadly, Curve pools can be split into three categories:
+
+* ``Plain pools``
+* ``Lending pools``
+* ``Metapools``
+
+Source code for Curve pools may be viewed on `GitHub <https://github.com/curvefi/curve-contract/tree/master/contracts>`_.
+
+.. warning::
+    The API for plain, lending and metapools applies to all pools that are implemented based on `pool templates <https://github.com/curvefi/curve-contract/tree/master/contracts/pool-templates>`_. When interacting with older Curve pools, there may be differences in terms of visibility, gas efficiency and/or variable naming. Please **do not** assume for a Curve pool to implement the API outlined in this section and verify this.
+
+For any code style information, please refer to the official :ref:`style guide <guide-code-style>`.
+
+
+Plain Pools
+===========
+
+The simplest Curve pool is a plain pool, which is an implementation of the StableSwap invariant for two or more tokens. The key characteristic of a plain pool is that the pool contract holds **all** deposited assets at all times.
+
+An example of a Curve plain pool is `3Pool <https://github.com/curvefi/curve-contract/tree/master/contracts/pools/3pool>`_, which contains the tokens ``DAI``, ``USDC`` and ``USDT``.
+
+.. note::
+    The API of plain pools is also implemented by lending and metapools.
+
+The Brownie console interaction examples are using `EURS Pool <https://etherscan.io/address/0x0Ce6a5fF5217e38315f87032CF90686C96627CAA>`_.
+
+Getting Pool Info
+-----------------
+
+.. py:function:: StableSwap.coins(i: uint256) -> uint256: view
+
+    Getter for the array of swappable coins within the pool. The last coin will always be the LP token of the base pool.
+
+    .. code-block:: python
+
+        >>> pool.coins(0)
+        '0xdB25f211AB05b1c97D595516F45794528a807ad8'
+
+.. py:function:: StableSwap.balances(i: uint256) -> uint256: view
+
+    Getter for the pool balances array.
+
+    .. code-block:: python
+
+        >>> pool.balances(0)
+        2918187395
+
+.. py:function:: StableSwap.owner() -> uint256: view
+
+    Getter for the admin/owner of the pool.
+
+    .. code-block:: python
+
+        >>> pool.owner()
+        '0xeCb456EA5365865EbAb8a2661B0c503410e9B347'
+
+.. py:function:: StableSwap.lp_token() -> uint256: view
+
+    Getter for the :ref:`LP token <exchange-lp-tokens>` of the pool.
+
+    .. code-block:: python
+
+        >>> pool.lp_token()
+        '0x194eBd173F6cDacE046C53eACcE9B953F28411d1'
+
+
+.. py:function:: StableSwap.A() -> uint256: view
+
+    The :ref:`amplification coefficient <exchange-pools-A>` for the pool.
+
+    .. code-block:: python
+
+        >>> pool.A()
+        100
+
+.. py:function:: StableSwap.A_precise() -> uint256: view
+
+    The :ref:`amplification coefficient <exchange-pools-A>` for the pool not scaled by ``A_PRECISION`` (``100``).
+
+    .. code-block:: python
+
+        >>> pool.A_precise()
+        10000
+
+.. py:function:: StableSwap.get_virtual_price() -> uint256: view
+
+    The current price of the pool LP token relative to the underlying pool assets. Given as an integer with 1e18 precision.
+
+    .. code-block:: python
+
+        >>> pool.get_virtual_price()
+        1001692838188850782
+
+.. py:function:: StableSwap.fee() -> uint256: view
+
+    The pool swap fee, as an integer with 1e10 precision.
+
+    .. code-block:: python
+
+        >>> pool.fee()
+        4000000
+
+.. py:function:: StableSwap.admin_fee() -> uint256: view
+
+    The percentage of the swap fee that is taken as an admin fee, as an integer with with 1e10 precision.
+
+    For factory pools this is hardcoded at 50% (``5000000000``).
+
+    .. code-block:: python
+
+        >>> pool.admin_fee()
+        5000000000
+
+.. py:function:: StableSwap.calc_token_amount(_amounts: uint256[N_COINS], _is_deposit: bool) -> uint256: view
+
+    Calculate addition or reduction in token supply from a deposit or withdrawal.
+
+    * ``_amounts``: Amount of each coin being deposited
+    * ``_is_deposit``: Set True for deposits, False for withdrawals
+
+    Returns the expected amount of LP tokens received. This calculation accounts for slippage, but not fees.
+
+    .. code-block:: python
+
+        >>> pool.calc_token_amount([10**2, 10**18], True)
+        1996887509167925969
+
+Making Exchanges
+----------------
+
+.. py:function:: StableSwap.get_dy(i: int128, j: int128, _dx: uint256) -> uint256: view
+
+    Get the amount of coin ``j`` one would receive for swapping ``_dx`` of coin ``i``.
+
+    .. code-block:: python
+
+        >>> pool.get_dy(0, 1, 100)
+        996307731416690125
+
+    *Note*: In the ``EURS Pool``, the decimals for ``coins(0)`` and ``coins(1)`` are 2 and 18, respectively.
+
+.. py:function:: StableSwap.exchange(i: int128, j: int128, _dx: uint256, _min_dy: uint256) -> uint256
+
+    Perform an exchange between two coins.
+
+    * ``i``: Index value for the coin to send
+    * ``j``: Index value of the coin to receive
+    * ``_dx``: Amount of ``i`` being exchanged
+    * ``_min_dy``: Minimum amount of ``j`` to receive
+
+    Returns the actual amount of coin ``j`` received. Index values can be found via the ``coins`` public getter method.
+
+    .. code-block:: python
+
+        >>> expected = pool.get_dy(0, 1, 10**2) * 0.99
+        >>> pool.exchange(0, 1, 10**2, expected, {"from": alice})
+
+
+Adding/Removing Liquidity
+-------------------------
+
+.. py:function:: StableSwap.add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint256
+
+    Deposit coins into the pool.
+
+    * ``_amounts``: List of amounts of coins to deposit
+    * ``_min_mint_amount``: Minimum amount of LP tokens to mint from the deposit
+
+    Returns the amount of LP tokens received in exchange for the deposited tokens.
+
+
+.. py:function:: StableSwap.remove_liquidity(_amount: uint256, _min_amounts: uint256[N_COINS]) -> uint256[N_COINS]
+
+    Withdraw coins from the pool.
+
+    * ``_amount``: Quantity of LP tokens to burn in the withdrawal
+    * ``_min_amounts``: Minimum amounts of underlying coins to receive
+
+    Returns a list of the amounts for each coin that was withdrawn.
+
+.. py:function:: StableSwap.remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uint256) -> uint256
+
+    Withdraw coins from the pool in an imbalanced amount.
+
+    * ``_amounts``: List of amounts of underlying coins to withdraw
+    * ``_max_burn_amount``: Maximum amount of LP token to burn in the withdrawal
+
+    Returns actual amount of the LP tokens burned in the withdrawal.
+
+.. py:function:: StableSwap.calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256
+
+    Calculate the amount received when withdrawing a single coin.
+
+    * ``_token_amount``: Amount of LP tokens to burn in the withdrawal
+    * ``i``: Index value of the coin to withdraw
+
+.. py:function:: StableSwap.remove_liquidity_one_coin(_token_amount: uint256, i: int128, _min_amount: uint256) -> uint256
+
+    Withdraw a single coin from the pool.
+
+    * ``_token_amount``: Amount of LP tokens to burn in the withdrawal
+    * ``i``: Index value of the coin to withdraw
+    * ``_min_amount``: Minimum amount of coin to receive
+
+    Returns the amount of coin ``i`` received.
+
+
+Lending Pools
+=============
+
+Curve pools may contain lending functionality, whereby the underlying tokens are lent out on other protocols (e.g., Compound or Yearn). Hence, the main difference to a plain pool is that a lending pool does **not** hold the underlying token itself, but rather a **wrapped** representation of it. By allocating liquidity to other protocols, liquidity providers to the Curve pool can receive interest in addition to trading fees.
+
+An example of a Curve lending pool is `Compound Pool <https://github.com/curvefi/curve-contract/tree/master/contracts/pools/compound>`_, which contains the wrapped tokens ``cDAI`` and ``cUSDC``, while the underlying tokens ``DAI`` and ``USDC`` are lent out on Compound. Liquidity providers of the Compound Pool therefore receive interest generated on Compound in addition to fees from token swaps in the pool.
+
+Implementation of lending pools may differ with respect to how wrapped tokens accrue interest. There are two main types of wrapped tokens that are used by lending pools:
+
+    * ``cToken-style tokens``: These are tokens, such as interest-bearing cTokens on Compound (e.g., ``cDAI``), where interest accrues as the rate of the token increases.
+    * ``aToken-style tokens``: These are tokens, such as aTokens on AAVE (e.g., ``aDAI``), where interest accrues as the balance of the token increases.
+
+
+Making Exchanges
+----------------
+
+.. py:function:: StableSwap.exchange_underlying(i: int128, j: int128, dx: uint256, min_dy: uint256)
+
+    Perform an exchange between two **underlying** tokens. Index values can be found via the ``underlying_coins`` public getter method.
+
+
+
+
+Metapools
+=========
+
+
+
+Admin Pool Settings
+===================
+
+The following are methods that may only be called by the pool admin (``owner``).
+
+Additionally, some admin methods require a two-phase transaction process, whereby changes are committed in a first transaction and after a forced delay applied via a second transaction. The minimum delay after which a committed action can be applied is given by the constant pool attribute ``admin_actions_delay``, which is set to 3 days.
+
+Pool Ownership
+--------------
+
+.. py:function:: StableSwap.commit_transfer_ownership(_owner: address)
+
+    Initiate an ownership transfer of pool to ``_owner``.
+
+    Callable only by the ownership admin. The ownership can not be transferred before ``transfer_ownership_deadline``, which is the timestamp of the current block delayed by ``admin_actions_delay``.
+
+.. py:function:: StableSwap.apply_transfer_ownership()
+
+    Transfers ownership of the pool from current owner to the owner previously set via ``commit_transfer_ownership``.
+
+    .. warning::
+        Pool ownership can only be transferred once.
+
+
+.. py:function:: StableSwap.revert_transfer_ownership()
+
+    Reverts any previously committed transfer of ownership. This method resets the ``transfer_ownership_deadline`` to ``0``.
+
+.. _exchange-pools-A:
+
+Amplification Coefficient
+-------------------------
+
+The amplification co-efficient (“A”) determines a pool’s tolerance for imbalance between the assets within it. A higher value means that trades will incure slippage sooner as the assets within the pool become imbalanced.
+
+The appropriate value for A is dependent upon the type of coin being used within the pool.
+
+It is possible to modify the amplification coefficient for a pool after it has been deployed. However, it requires a vote within the Curve DAO and must reach a 15% quorum.
+
+.. py:function:: StableSwap.ramp_A(_future_A: uint256, _future_time: uint256)
+
+    Ramp ``A`` up or down by setting a new ``A`` to take effect at a future point in time.
+
+    * ``_future_A``: New future value of ``A``
+    * ``_future_time``: Timestamp at which new ``A`` should take effect
+
+.. py:function:: StableSwap.stop_ramp_A()
+
+    Stops ramping ``A`` up or down and sets ``A`` to current ``A``.
+
+
+Trade Fees
+----------
+
+.. py:function:: StableSwap.commit_new_fee(_new_fee: uint256, _new_admin_fee: uint256)
+
+    Commits new pool and admin fees for the pool. These fees do not take immediate effect.
+
+    * ``_new_fee``: New pool fee
+    * ``_new_admin_fee``: New admin fee (expressed as a percentage of the pool fee)
+
+.. note::
+    Both the pool ``fee`` and the ``admin_fee`` are capped by the constants ``MAX_FEE`` and ``MAX_ADMIN_FEE``, respectively. By default ``MAX_FEE`` is set at 50% and ``MAX_ADMIN_FEE`` at 100% (which is charged on the ``MAX_FEE`` amount).
+
+.. py:function:: StableSwap.apply_new_fee()
+
+    Applies the previously committed new pool and admin fees for the pool.
+
+    .. note::
+        Unlike ownership transfers, pool and admin fees may be set more than once.
+
+.. py:function:: StableSwap.revert_new_parameters()
+
+    Resets any previously committed new fees.
+
+.. py:function:: StableSwap.admin_balances(i: uint256) -> uint256
+
+    Get the admin balance for a single coin in the pool.
+
+    * ``i``: Index of the coin to get admin balance for
+
+    Returns the admin balance for coin ``i``.
+
+.. py:function:: StableSwap.withdraw_admin_fees()
+
+    Withdraws and transfers admin fees of the pool to the pool owner.
+
+.. py:function:: StableSwap.donate_admin_fees()
+
+    Donates all admin fees to the pool's liquidity providers.
+
+
+Kill a Pool
+-----------
+
+.. py:function:: StableSwap.kill_me()
+
+    Pause a pool by setting the ``is_killed`` boolean flag to ``True``.
+
+    This disables the following pool functionality:
+    * ``add_liquidity``
+    * ``exchange``
+    * ``remove_liquidity_imbalance``
+    * ``remove_liquidity_one_coin``
+
+    Hence, when paused, it is only possible for existing LPs to remove liquidity via ``remove_liquidity``.
+
+.. py:function:: StableSwap.unkill_me()
+
+    Unpause a pool that was previously paused, re-enabling exchanges.

--- a/docs/ref-addresses.rst
+++ b/docs/ref-addresses.rst
@@ -61,6 +61,7 @@ Here is a list of all base pool contracts currently in use:
    Yv2, `StableSwapYv2.vy <https://github.com/curvefi/curve-contract/blob/master/contracts/pools/yv2/StableSwapYv2.vy>`_, `0x8925D9d9B4569D737a48499DeF3f67BaA5a144b9 <https://etherscan.io/address/0x8925D9d9B4569D737a48499DeF3f67BaA5a144b9#code>`_
    Yv2, `CurveTokenV3.vy <https://github.com/curvefi/curve-contract/blob/master/contracts/tokens/CurveTokenV3.vy>`_, `0x571FF5b7b346F706aa48d696a9a4a288e9Bb4091 <https://etherscan.io/address/0x571FF5b7b346F706aa48d696a9a4a288e9Bb4091#code>`_
 
+.. _addresses-metapools:
 
 Meta Pools
 ==========

--- a/docs/ref-glossary.rst
+++ b/docs/ref-glossary.rst
@@ -13,6 +13,9 @@ This section is a work in progress - if a term is missing, feel free to `open a 
 Automated Market Maker (AMM)
     A decentralized asset trading pool that allows participants to buy or sell cryptocurrencies.
 
+Base Pool
+    The pool issuing the LP token that is used by a metapool.
+
 Burning
     The process of withdrawing admin fees from the excahange contracts and distributing them to veCRV holders.
 
@@ -25,7 +28,7 @@ LP Token
 .. _glossary-metapool:
 
 Metapool
-    A Curve pool where one of the tradeable assets is the :ref:`LP token<glossary-metapool>` for another pool. Metapools are used to prevent liquidity fragmentation.
+    A Curve pool where one of the tradeable assets is the :ref:`LP token<glossary-metapool>` for another pool (base pool). Metapools are used to prevent liquidity fragmentation.
 
 .. _glossary-underlying-coin:
 

--- a/docs/registry-overview.rst
+++ b/docs/registry-overview.rst
@@ -1,9 +1,9 @@
 .. _overview:
 
 
-==================
-Registry: Overview
-==================
+========
+Registry
+========
 
 The Curve registry contracts are open source and may be `found on Github <https://github.com/curvefi/curve-pool-registry>`_.
 

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -11,15 +11,15 @@ Curve
     :maxdepth: 2
     :caption: StableSwap Exchange
 
+    Overview <exchange-overview.rst>
+    Pools <exchange-pools.rst>
+    LP Tokens <exchange-lp-tokens.rst>
+    Deposit Contracts <exchange-deposits.rst>
     Cross-Asset Swaps <exchange-cross-asset-swaps.rst>
 
 ..
     As these sections are completed, add them above cross asset swaps!
 
-    Overview <exchange-overview.rst>
-    Pools <exchange-pools.rst>
-    LP Tokens <exchange-lp-tokens.rst>
-    Deposit Contracts <exchange-deposits.rst>
 ..
 
 

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -17,12 +17,6 @@ Curve
     Deposit Contracts <exchange-deposits.rst>
     Cross-Asset Swaps <exchange-cross-asset-swaps.rst>
 
-..
-    As these sections are completed, add them above cross asset swaps!
-
-..
-
-
 .. toctree::
     :maxdepth: 2
     :caption: Curve DAO


### PR DESCRIPTION
## What I did

Added the following sections to the `StableSwap Exchange` docs:
* Overview
* Curve Pools (Plain, Lending, Meta)
* LP Tokens
* Deposit Zaps

