### PR TITLE
Added Fundraising Gauge to active gauge types list

### DIFF
--- a/docs/dao-gauges.rst
+++ b/docs/dao-gauges.rst
@@ -97,6 +97,7 @@ Currently active gauge types are as follows:
    * Arbitrum ``7``
    * Avalanche ``8``
    * Harmony ``9``
+   * Fundraising ``10`` 
 
 Types ``3`` and ``6`` have been deprecated.
 


### PR DESCRIPTION
After the successful governance proposal https://dao.curve.fi/vote/ownership/142 the Fundraising Gauge type was added at Ethereum block 14441032.