### PR TITLE
Fixing bug in registry-registry.rst

### DIFF
--- a/docs/registry-registry.rst
+++ b/docs/registry-registry.rst
@@ -324,8 +324,8 @@ Pool Metadata
     Asset types are as follows:
 
         * ``0``: USD
-        * ``1``: BTC
-        * ``2``: ETH
+        * ``1``: ETH
+        * ``2``: BTC
         * ``3``: Other StableSwap
         * ``4``: CryptoSwap
 


### PR DESCRIPTION
The main registry contract deployed at 90E00ACE148CA3B23AC1BC8C240C2A7DD9C2D7F5 seems to suggest that asset type 1 is ETH and asset type 2 is BTC.
